### PR TITLE
個人サイトをエディトリアル組版にリデザイン

### DIFF
--- a/en.html
+++ b/en.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="ja">
+<html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>水島 宏太 — Web Pages</title>
-<meta name="description" content="水島 宏太 (Kota Mizushima) — ソフトウェアエンジニア／研究者。プログラミング言語・構文解析・Scala 実務。" />
+<title>Kota Mizushima — Web Pages</title>
+<meta name="description" content="Kota Mizushima — Software Engineer & Researcher. Programming languages, parsing, and practical Scala." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;0,8..60,600;1,8..60,400&family=Noto+Serif+JP:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -461,7 +461,7 @@
   }
 </style>
 </head>
-<body data-lang="ja">
+<body data-lang="en">
 
 <div class="page">
 
@@ -481,10 +481,10 @@
       <span class="only-ja">ソフトウェアエンジニア／研究者 — プログラミング言語・構文解析・Scala 実務</span>
     </p>
     <div class="mast-meta">
-      <span>博士（工学）／ Ph.D., Computer Science</span>
+      <span>Ph.D., Computer Science</span>
       <span class="lang-toggle">
-        <button class="active" data-lang="ja">JA</button>
-        <a href="en.html" data-lang="en" style="text-decoration:none;border:0;"><button type="button" tabindex="-1">EN</button></a>
+        <a href="index.html" data-lang="ja" style="text-decoration:none;border:0;"><button type="button" tabindex="-1">JA</button></a>
+        <button class="active" data-lang="en">EN</button>
       </span>
     </div>
   </header>


### PR DESCRIPTION
## Summary

- `index.html` を全面刷新し、EB Garamond + Noto Serif JP + JetBrains Mono のスカラリーな組版に。目次（I〜VI）、点線リーダー、`[N]` 形式の文献番号、自著名の下線強調といった学術慣習に揃えました。
- `en.html` を新規追加し、ヘッダー右上で JA/EN を切替可能に（同内容の英語版）。
- 論文 PDF へのリンクを `https://kmizu.github.io/papers/...` から相対パス `papers/...` に正規化。
- `<meta name=\"description\">` を追加。
- Other Activity に ScalaMatsuri 2017 / 2018 / 2019 のスライドと、自作言語 Klassic を追加。

## デザインの方向性

- 紙背景（cream）+ 黒インク、装飾は罫線と余白で構造を作る。
- ローマ数字の章立て・点線リーダーで研究者ページにふさわしい格調を意識。
- 派手なホバー効果や色面はなし。
- メールアドレスは `[atmark]` で隠して reveal+copy ボタンで開示する形に。

## Test plan

- [x] `index.html` をブラウザで開いて、和文の各セクション（プロフィール・論文・著書・活動・連絡先）の表示を確認
- [x] `en.html` をブラウザで開いて、英文の各セクションの表示を確認
- [x] 右上の JA / EN ボタンで `index.html` ⇄ `en.html` の遷移を確認
- [x] 連絡先の "表示してコピー" ボタンでクリップボードにコピーされることを確認
- [x] 論文 PDF リンクが `papers/*.pdf` で開くことを確認
- [x] スマホ幅（< 600px）でレイアウトが崩れないことを確認