### PR TITLE
論文一覧を査読あり／なしで分割し、所属企業の言及を削除

### DIFF
--- a/en.html
+++ b/en.html
@@ -468,8 +468,8 @@
   <!-- ===== Masthead ===== -->
   <header class="mast">
     <div class="institution">
-      <span class="only-en">Nextbeat Co., Ltd. · Tokyo · Updated April 2026</span>
-      <span class="only-ja">株式会社ネクストビート · 東京 · 2026年4月更新</span>
+      <span class="only-en">Tokyo · Updated April 2026</span>
+      <span class="only-ja">東京 · 2026年4月更新</span>
     </div>
     <p class="name-jp">水島 宏太</p>
     <h1>
@@ -508,19 +508,13 @@
     </h2>
 
     <p class="only-en">
-      Software engineer at Nextbeat Co., Ltd. My research and writing concern the design and implementation of programming languages, with a particular focus on <em>Packrat parsing</em> and Parsing Expression Grammars (PEG). I have been active in the Japanese Scala community since its early days and have co-authored two books on practical Scala for working engineers.
+      Software engineer. My research and writing concern the design and implementation of programming languages, with a particular focus on <em>Packrat parsing</em> and Parsing Expression Grammars (PEG). I have been active in the Japanese Scala community since its early days and have co-authored two books on practical Scala for working engineers.
     </p>
     <p class="only-ja">
-      株式会社ネクストビート所属のソフトウェアエンジニア。プログラミング言語の設計と実装、とりわけ <em>Packrat Parsing</em> および解析表現文法（PEG）の研究を続けています。日本の Scala コミュニティの初期から活動を続けており、Scala 実務に関する書籍を共著として 2 冊上梓しました。
+      ソフトウェアエンジニア。プログラミング言語の設計と実装、とりわけ <em>Packrat Parsing</em> および解析表現文法（PEG）の研究を続けています。日本の Scala コミュニティの初期から活動を続けており、Scala 実務に関する書籍を共著として 2 冊上梓しました。
     </p>
 
     <dl class="profile">
-      <dt><span class="only-en">Affiliation</span><span class="only-ja">所属</span></dt>
-      <dd>
-        <span class="only-en">Nextbeat Co., Ltd. <span class="note">Software Engineer</span></span>
-        <span class="only-ja">株式会社ネクストビート <span class="note">ソフトウェアエンジニア</span></span>
-      </dd>
-
       <dt><span class="only-en">Degree</span><span class="only-ja">学位</span></dt>
       <dd>
         <span class="only-en">Ph.D., Computer Science</span>
@@ -552,6 +546,35 @@
       <span class="roman">ii.</span>
     </h2>
 
+    <div class="bib-group">
+      <span class="only-en">Refereed Journal Papers</span>
+      <span class="only-ja">査読付き論文</span>
+    </div>
+    <ol class="bibliography">
+      <li>
+        <div class="entry">
+          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+          <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
+          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>，
+          <span class="year">March&nbsp;2011</span>．
+          <a class="pdf" href="papers/IPSJ-TPRO0402007.pdf" target="_blank" rel="noopener">PDF</a>
+        </div>
+      </li>
+      <li>
+        <div class="entry">
+          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
+          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>，
+          <span class="year">January&nbsp;2008</span>．
+          <a class="pdf" href="papers/pro_35-mizushima.pdf" target="_blank" rel="noopener">PDF</a>
+        </div>
+      </li>
+    </ol>
+
+    <div class="bib-group">
+      <span class="only-en">Non-refereed Presentations &amp; Workshop Proceedings</span>
+      <span class="only-ja">研究会発表・予稿集</span>
+    </div>
     <ol class="bibliography">
       <li>
         <div class="entry">
@@ -566,26 +589,8 @@
         <div class="entry">
           <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
           <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
-          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>，
-          <span class="year">March&nbsp;2011</span>．
-          <a class="pdf" href="papers/IPSJ-TPRO0402007.pdf" target="_blank" rel="noopener">PDF</a>
-        </div>
-      </li>
-      <li>
-        <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
           <span class="venue">情報処理学会第 81 回プログラミング研究会</span>，
           <span class="year">October&nbsp;2010</span>．
-        </div>
-      </li>
-      <li>
-        <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
-          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>，
-          <span class="year">January&nbsp;2008</span>．
-          <a class="pdf" href="papers/pro_35-mizushima.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -468,8 +468,8 @@
   <!-- ===== Masthead ===== -->
   <header class="mast">
     <div class="institution">
-      <span class="only-en">Nextbeat Co., Ltd. · Tokyo · Updated April 2026</span>
-      <span class="only-ja">株式会社ネクストビート · 東京 · 2026年4月更新</span>
+      <span class="only-en">Tokyo · Updated April 2026</span>
+      <span class="only-ja">東京 · 2026年4月更新</span>
     </div>
     <p class="name-jp">水島 宏太</p>
     <h1>
@@ -508,19 +508,13 @@
     </h2>
 
     <p class="only-en">
-      Software engineer at Nextbeat Co., Ltd. My research and writing concern the design and implementation of programming languages, with a particular focus on <em>Packrat parsing</em> and Parsing Expression Grammars (PEG). I have been active in the Japanese Scala community since its early days and have co-authored two books on practical Scala for working engineers.
+      Software engineer. My research and writing concern the design and implementation of programming languages, with a particular focus on <em>Packrat parsing</em> and Parsing Expression Grammars (PEG). I have been active in the Japanese Scala community since its early days and have co-authored two books on practical Scala for working engineers.
     </p>
     <p class="only-ja">
-      株式会社ネクストビート所属のソフトウェアエンジニア。プログラミング言語の設計と実装、とりわけ <em>Packrat Parsing</em> および解析表現文法（PEG）の研究を続けています。日本の Scala コミュニティの初期から活動を続けており、Scala 実務に関する書籍を共著として 2 冊上梓しました。
+      ソフトウェアエンジニア。プログラミング言語の設計と実装、とりわけ <em>Packrat Parsing</em> および解析表現文法（PEG）の研究を続けています。日本の Scala コミュニティの初期から活動を続けており、Scala 実務に関する書籍を共著として 2 冊上梓しました。
     </p>
 
     <dl class="profile">
-      <dt><span class="only-en">Affiliation</span><span class="only-ja">所属</span></dt>
-      <dd>
-        <span class="only-en">Nextbeat Co., Ltd. <span class="note">Software Engineer</span></span>
-        <span class="only-ja">株式会社ネクストビート <span class="note">ソフトウェアエンジニア</span></span>
-      </dd>
-
       <dt><span class="only-en">Degree</span><span class="only-ja">学位</span></dt>
       <dd>
         <span class="only-en">Ph.D., Computer Science</span>
@@ -552,6 +546,35 @@
       <span class="roman">ii.</span>
     </h2>
 
+    <div class="bib-group">
+      <span class="only-en">Refereed Journal Papers</span>
+      <span class="only-ja">査読付き論文</span>
+    </div>
+    <ol class="bibliography">
+      <li>
+        <div class="entry">
+          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+          <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
+          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>，
+          <span class="year">March&nbsp;2011</span>．
+          <a class="pdf" href="papers/IPSJ-TPRO0402007.pdf" target="_blank" rel="noopener">PDF</a>
+        </div>
+      </li>
+      <li>
+        <div class="entry">
+          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
+          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>，
+          <span class="year">January&nbsp;2008</span>．
+          <a class="pdf" href="papers/pro_35-mizushima.pdf" target="_blank" rel="noopener">PDF</a>
+        </div>
+      </li>
+    </ol>
+
+    <div class="bib-group">
+      <span class="only-en">Non-refereed Presentations &amp; Workshop Proceedings</span>
+      <span class="only-ja">研究会発表・予稿集</span>
+    </div>
     <ol class="bibliography">
       <li>
         <div class="entry">
@@ -566,26 +589,8 @@
         <div class="entry">
           <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
           <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
-          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>，
-          <span class="year">March&nbsp;2011</span>．
-          <a class="pdf" href="papers/IPSJ-TPRO0402007.pdf" target="_blank" rel="noopener">PDF</a>
-        </div>
-      </li>
-      <li>
-        <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
           <span class="venue">情報処理学会第 81 回プログラミング研究会</span>，
           <span class="year">October&nbsp;2010</span>．
-        </div>
-      </li>
-      <li>
-        <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
-          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>，
-          <span class="year">January&nbsp;2008</span>．
-          <a class="pdf" href="papers/pro_35-mizushima.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>
       <li>


### PR DESCRIPTION
## Summary

- 論文（和文）を「査読付き論文」と「研究会発表・予稿集」の 2 グループに分割。情報処理学会論文誌プログラミングの 2 件を査読論文として上に、SWoPP / 各種研究会 / PPL ショートプレゼンテーションを下のグループに整理。
- 個人ページのため、masthead と Profile セクションから所属企業（Nextbeat）の言及を削除。
  - masthead の institution 行を `Tokyo · Updated April 2026` / `東京 · 2026年4月更新` に。
  - Profile の冒頭文から「株式会社ネクストビート所属の」を削除。
  - `dl.profile` から「Affiliation / 所属」行を削除。

論文（英文）は項目数が 1 件のため構造変更なし。

## Test plan

- [x] `index.html` で論文（和文）が「査読付き論文」「研究会発表・予稿集」の 2 グループに分かれて表示される
- [x] 各グループが [1], [2], ... と独立して番号付けされる
- [x] masthead に Nextbeat の表記がない
- [x] Profile 冒頭文に「ネクストビート所属」が残っていない
- [x] Profile の所属行が消えている（Degree / Research / GitHub / Twitter / Blog のみ）
- [x] `en.html` でも同等の状態になっている