### PR TITLE
論文（英文）に「査読付きワークショップ論文」サブヘッダを追加

### DIFF
--- a/en.html
+++ b/en.html
@@ -629,6 +629,10 @@
       <span class="roman">iii.</span>
     </h2>
 
+    <div class="bib-group">
+      <span class="only-en">Refereed Workshop Papers</span>
+      <span class="only-ja">査読付きワークショップ論文</span>
+    </div>
     <ol class="bibliography">
       <li>
         <div class="entry">

--- a/index.html
+++ b/index.html
@@ -629,6 +629,10 @@
       <span class="roman">iii.</span>
     </h2>
 
+    <div class="bib-group">
+      <span class="only-en">Refereed Workshop Papers</span>
+      <span class="only-ja">査読付きワークショップ論文</span>
+    </div>
     <ol class="bibliography">
       <li>
         <div class="entry">


### PR DESCRIPTION
## Summary

論文（和文）と同じ構造に合わせ、論文（英文）にもグループ見出しを追加。

PASTE 2010（ACM SIGPLAN-SIGSOFT Workshop on Program Analysis for Software Tools and Engineering）はピアレビュー付きワークショップのため、`Refereed Workshop Papers` / `査読付きワークショップ論文` というラベルでグループ化。

## Test plan

- [x] `index.html` / `en.html` の Publications (English) / 論文（英文）セクションに「査読付きワークショップ論文」のサブヘッダが表示される
- [x] PASTE 2010 の論文項目が `[1]` として表示される（番号は維持）