### PR TITLE
en.html: 論文（和文）の英訳を表示するように

### DIFF
--- a/en.html
+++ b/en.html
@@ -288,6 +288,14 @@
     font-variant-numeric: tabular-nums;
     color: var(--ink-3);
   }
+  ol.bibliography .lang-tag {
+    color: var(--ink-4);
+    font-size: 0.82em;
+    font-style: normal;
+    font-family: var(--mono);
+    letter-spacing: .02em;
+    margin-left: 2px;
+  }
   ol.bibliography .pdf {
     font-family: var(--mono);
     font-size: 11px;
@@ -553,19 +561,35 @@
     <ol class="bibliography">
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
-          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>，
-          <span class="year">March&nbsp;2011</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
+            <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>，
+            <span class="year">March&nbsp;2011</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“A Method for Analyzing the Space Complexity of Optimized Packrat Parsers”</span>.
+            <span class="venue">IPSJ Transactions on Programming, Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>,
+            <span class="year">March&nbsp;2011</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
           <a class="pdf" href="papers/IPSJ-TPRO0402007.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
-          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>，
-          <span class="year">January&nbsp;2008</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
+            <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>，
+            <span class="year">January&nbsp;2008</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“A Memory-Efficiency Improvement Method for Packrat Parsing”</span>.
+            <span class="venue">IPSJ Transactions on Programming, Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>,
+            <span class="year">January&nbsp;2008</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
           <a class="pdf" href="papers/pro_35-mizushima.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>
@@ -578,43 +602,83 @@
     <ol class="bibliography">
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span></span>．
-          <span class="title">「PEG のパラメタ付き拡張 Macro PEG の提案」</span>．
-          <span class="venue">第 110 回プログラミング研究発表会（SWoPP 2016）</span>，
-          <span class="year">August&nbsp;2016</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span></span>．
+            <span class="title">「PEG のパラメタ付き拡張 Macro PEG の提案」</span>．
+            <span class="venue">第 110 回プログラミング研究発表会（SWoPP 2016）</span>，
+            <span class="year">August&nbsp;2016</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span></span>.
+            <span class="title">“Macro PEG: A Parameterized Extension of PEG”</span>.
+            <span class="venue">110th IPSJ SIGPRO Programming Workshop (SWoPP 2016)</span>,
+            <span class="year">August&nbsp;2016</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
           <a class="pdf" href="papers/SWoPP2016-mizushima.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
-          <span class="venue">情報処理学会第 81 回プログラミング研究会</span>，
-          <span class="year">October&nbsp;2010</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
+            <span class="venue">情報処理学会第 81 回プログラミング研究会</span>，
+            <span class="year">October&nbsp;2010</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“A Method for Analyzing the Space Complexity of Optimized Packrat Parsers”</span>.
+            <span class="venue">81st IPSJ SIGPRO Workshop</span>,
+            <span class="year">October&nbsp;2010</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
-          <span class="venue">第 65 回情報処理学会プログラミング研究会</span>，
-          <span class="year">August&nbsp;2007</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
+            <span class="venue">第 65 回情報処理学会プログラミング研究会</span>，
+            <span class="year">August&nbsp;2007</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“A Memory-Efficiency Improvement Method for Packrat Parsing”</span>.
+            <span class="venue">65th IPSJ SIGPRO Workshop</span>,
+            <span class="year">August&nbsp;2007</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司</span>．
-          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
-          <span class="venue">第 9 回プログラミングおよびプログラミング言語ワークショップ（PPL 2007）ショートプレゼンテーション</span>，
-          <span class="year">March&nbsp;2007</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司</span>．
+            <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
+            <span class="venue">第 9 回プログラミングおよびプログラミング言語ワークショップ（PPL 2007）ショートプレゼンテーション</span>，
+            <span class="year">March&nbsp;2007</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span> and Atusi Maeda</span>.
+            <span class="title">“A Memory-Efficiency Improvement Method for Packrat Parsing”</span>.
+            <span class="venue">Short Presentation, 9th Workshop on Programming and Programming Languages (PPL 2007)</span>,
+            <span class="year">March&nbsp;2007</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「プログラミング言語 Onion の設計と実装」</span>．
-          <span class="venue">第 55 回情報処理学会プログラミング研究会</span>，
-          <span class="year">August&nbsp;2005</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「プログラミング言語 Onion の設計と実装」</span>．
+            <span class="venue">第 55 回情報処理学会プログラミング研究会</span>，
+            <span class="year">August&nbsp;2005</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“Design and Implementation of the Programming Language Onion”</span>.
+            <span class="venue">55th IPSJ SIGPRO Workshop</span>,
+            <span class="year">August&nbsp;2005</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
           <a class="pdf" href="papers/IPSJ-TPRO4702018.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>

--- a/index.html
+++ b/index.html
@@ -288,6 +288,14 @@
     font-variant-numeric: tabular-nums;
     color: var(--ink-3);
   }
+  ol.bibliography .lang-tag {
+    color: var(--ink-4);
+    font-size: 0.82em;
+    font-style: normal;
+    font-family: var(--mono);
+    letter-spacing: .02em;
+    margin-left: 2px;
+  }
   ol.bibliography .pdf {
     font-family: var(--mono);
     font-size: 11px;
@@ -553,19 +561,35 @@
     <ol class="bibliography">
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
-          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>，
-          <span class="year">March&nbsp;2011</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
+            <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>，
+            <span class="year">March&nbsp;2011</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“A Method for Analyzing the Space Complexity of Optimized Packrat Parsers”</span>.
+            <span class="venue">IPSJ Transactions on Programming, Vol.&nbsp;4, No.&nbsp;2, pp.&nbsp;77–91</span>,
+            <span class="year">March&nbsp;2011</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
           <a class="pdf" href="papers/IPSJ-TPRO0402007.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
-          <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>，
-          <span class="year">January&nbsp;2008</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
+            <span class="venue">情報処理学会論文誌プログラミング，Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>，
+            <span class="year">January&nbsp;2008</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“A Memory-Efficiency Improvement Method for Packrat Parsing”</span>.
+            <span class="venue">IPSJ Transactions on Programming, Vol.&nbsp;49, No.&nbsp;SIG&nbsp;1 (PRO 35), pp.&nbsp;117–126</span>,
+            <span class="year">January&nbsp;2008</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
           <a class="pdf" href="papers/pro_35-mizushima.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>
@@ -578,43 +602,83 @@
     <ol class="bibliography">
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span></span>．
-          <span class="title">「PEG のパラメタ付き拡張 Macro PEG の提案」</span>．
-          <span class="venue">第 110 回プログラミング研究発表会（SWoPP 2016）</span>，
-          <span class="year">August&nbsp;2016</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span></span>．
+            <span class="title">「PEG のパラメタ付き拡張 Macro PEG の提案」</span>．
+            <span class="venue">第 110 回プログラミング研究発表会（SWoPP 2016）</span>，
+            <span class="year">August&nbsp;2016</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span></span>.
+            <span class="title">“Macro PEG: A Parameterized Extension of PEG”</span>.
+            <span class="venue">110th IPSJ SIGPRO Programming Workshop (SWoPP 2016)</span>,
+            <span class="year">August&nbsp;2016</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
           <a class="pdf" href="papers/SWoPP2016-mizushima.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
-          <span class="venue">情報処理学会第 81 回プログラミング研究会</span>，
-          <span class="year">October&nbsp;2010</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「最適化 Packrat Parser の空間計算量の計算手法の提案」</span>．
+            <span class="venue">情報処理学会第 81 回プログラミング研究会</span>，
+            <span class="year">October&nbsp;2010</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“A Method for Analyzing the Space Complexity of Optimized Packrat Parsers”</span>.
+            <span class="venue">81st IPSJ SIGPRO Workshop</span>,
+            <span class="year">October&nbsp;2010</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
-          <span class="venue">第 65 回情報処理学会プログラミング研究会</span>，
-          <span class="year">August&nbsp;2007</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
+            <span class="venue">第 65 回情報処理学会プログラミング研究会</span>，
+            <span class="year">August&nbsp;2007</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“A Memory-Efficiency Improvement Method for Packrat Parsing”</span>.
+            <span class="venue">65th IPSJ SIGPRO Workshop</span>,
+            <span class="year">August&nbsp;2007</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司</span>．
-          <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
-          <span class="venue">第 9 回プログラミングおよびプログラミング言語ワークショップ（PPL 2007）ショートプレゼンテーション</span>，
-          <span class="year">March&nbsp;2007</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司</span>．
+            <span class="title">「Packrat Parsing のメモリ効率の改善手法」</span>．
+            <span class="venue">第 9 回プログラミングおよびプログラミング言語ワークショップ（PPL 2007）ショートプレゼンテーション</span>，
+            <span class="year">March&nbsp;2007</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span> and Atusi Maeda</span>.
+            <span class="title">“A Memory-Efficiency Improvement Method for Packrat Parsing”</span>.
+            <span class="venue">Short Presentation, 9th Workshop on Programming and Programming Languages (PPL 2007)</span>,
+            <span class="year">March&nbsp;2007</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
         </div>
       </li>
       <li>
         <div class="entry">
-          <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
-          <span class="title">「プログラミング言語 Onion の設計と実装」</span>．
-          <span class="venue">第 55 回情報処理学会プログラミング研究会</span>，
-          <span class="year">August&nbsp;2005</span>．
+          <span class="only-ja">
+            <span class="authors"><span class="self">水島 宏太</span>，前田 敦司，山口 喜教</span>．
+            <span class="title">「プログラミング言語 Onion の設計と実装」</span>．
+            <span class="venue">第 55 回情報処理学会プログラミング研究会</span>，
+            <span class="year">August&nbsp;2005</span>．
+          </span>
+          <span class="only-en">
+            <span class="authors"><span class="self">Kota Mizushima</span>, Atusi Maeda, and Yoshinori Yamaguchi</span>.
+            <span class="title">“Design and Implementation of the Programming Language Onion”</span>.
+            <span class="venue">55th IPSJ SIGPRO Workshop</span>,
+            <span class="year">August&nbsp;2005</span>. <span class="lang-tag">(in Japanese)</span>
+          </span>
           <a class="pdf" href="papers/IPSJ-TPRO4702018.pdf" target="_blank" rel="noopener">PDF</a>
         </div>
       </li>


### PR DESCRIPTION
## Summary

en.html を表示しているのに、論文（和文）セクションの各エントリが日本語のままだった件を修正。

各 `<li>` の中身を `.only-ja`（従来の日本語表記）と `.only-en`（新規追加の英訳）に分割。CSS の既存言語切替ルール（\`body[data-lang=\"en\"] .only-ja { display: none; }\`）により：

- **index.html（JA）**: 従来どおり日本語表記
- **en.html（EN）**: 英訳のみが表示され、語末に \`(in Japanese)\` のタグで原典が日本語であることを示す

英訳の方針：
- 著者名はローマ字表記（Kota Mizushima, Atusi Maeda, Yoshinori Yamaguchi）
- タイトルは英訳（例：「最適化 Packrat Parser の空間計算量の計算手法の提案」 → \"A Method for Analyzing the Space Complexity of Optimized Packrat Parsers\"）
- 会議・学会誌の英名（IPSJ Transactions on Programming, IPSJ SIGPRO Workshop など）

新規 CSS クラス \`.lang-tag\` で \`(in Japanese)\` を地味めに表示（mono、小さめ、薄い色）。

## Test plan

- [x] en.html を表示し、論文（和文）セクションが英訳で表示される
- [x] 各エントリの末尾に \`(in Japanese)\` が小さく表示される
- [x] index.html を表示し、論文（和文）セクションが従来どおり日本語のまま表示される
- [x] 数・並び順・PDF リンクが両ページで一致する

## 確認してほしいこと

英訳タイトルや会議名は適切な範囲で意訳しています。正式な英訳が別にあれば差し替えます。特に：

- \"A Method for Analyzing the Space Complexity of Optimized Packrat Parsers\"（情報処理学会論文誌 2011）
- \"A Memory-Efficiency Improvement Method for Packrat Parsing\"（同 2008）
- \"Macro PEG: A Parameterized Extension of PEG\"（SWoPP 2016）
- \"Design and Implementation of the Programming Language Onion\"（2005）

公式の英訳タイトルがあればお知らせください。